### PR TITLE
Fix jsonrpc client

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.2.3
 commit = True
 tag = True
 tag_name = {new_version}

--- a/dotmesh/__version__.py
+++ b/dotmesh/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'datadots-api'
 __description__ = 'Datadots API for Python'
 __url__ = 'https://github.com/dotmesh-io/python-sdk'
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __author__ = 'Michael Hausenblas'
 __author_email__ = 'michael.hausenblas@gmail.com'
 __license__ = 'Apache 2.0'

--- a/dotmesh/client.py
+++ b/dotmesh/client.py
@@ -75,7 +75,7 @@ class DotmeshClient(object):
         """
         Pings the cluster.
         """
-        return self.client.request("DotmeshRPC.Ping")
+        return self.client.request("DotmeshRPC.Ping").data.result
 
     def getDot(self, dotname, ns="admin"):
         """
@@ -89,7 +89,7 @@ class DotmeshClient(object):
             ns = dotname.namespace
             dotname = dotname.name
 
-        id = self.client.request("DotmeshRPC.Lookup", Namespace=ns, Name=dotname, Branch="")
+        id = self.client.request("DotmeshRPC.Lookup", Namespace=ns, Name=dotname, Branch="").data.result
         return Dot(client=self.client, id=id, name=dotname, ns=ns)
 
     def createDot(self, dotname, ns="admin"):
@@ -104,7 +104,7 @@ class DotmeshClient(object):
             ns = dotname.namespace
             dotname = dotname.name
 
-        self.client.request("DotmeshRPC.Create", Namespace=ns, Name=dotname)
+        self.client.request("DotmeshRPC.Create", Namespace=ns, Name=dotname).data.result
         return self.getDot(dotname, ns)
 
     def deleteDot(self, dotname, ns="admin"):
@@ -118,7 +118,7 @@ class DotmeshClient(object):
             ns = dotname.namespace
             dotname = dotname.name
 
-        return self.client.request("DotmeshRPC.Delete", Namespace=ns, Name=dotname)
+        return self.client.request("DotmeshRPC.Delete", Namespace=ns, Name=dotname).data.result
 
 class Dot(object):
     """
@@ -146,7 +146,7 @@ class Dot(object):
         bname = branchname
         if branchname == "master":
             bname = ""
-        self.client.request("DotmeshRPC.Lookup", Namespace=self.ns,Name=self.name, Branch=bname)
+        self.client.request("DotmeshRPC.Lookup", Namespace=self.ns,Name=self.name, Branch=bname).data.result
         return Branch(dot=self, name=branchname)
 
 class Branch(object):
@@ -172,7 +172,7 @@ class Branch(object):
         bname = self.name
         if self.name == "master":
             bname = ""
-        return self.dot.client.request("DotmeshRPC.Commit", Namespace=self.dot.ns, Name=self.dot.name, Branch=bname, Message=msg, Metadata=metadata)
+        return self.dot.client.request("DotmeshRPC.Commit", Namespace=self.dot.ns, Name=self.dot.name, Branch=bname, Message=msg, Metadata=metadata).data.result
 
     def log(self):
         """
@@ -181,7 +181,7 @@ class Branch(object):
         bname = self.name
         if self.name == "master":
             bname = ""
-        return self.dot.client.request("DotmeshRPC.Commits", Namespace=self.dot.ns, Name=self.dot.name, Branch=bname)
+        return self.dot.client.request("DotmeshRPC.Commits", Namespace=self.dot.ns, Name=self.dot.name, Branch=bname).data.result
 
     def createBranch(self, newbranchname, srcbranchname, commit_id=""):
         """
@@ -201,5 +201,5 @@ class Branch(object):
                                 Name=self.dot.name,
                                 SourceBranch=srcbranchname,
                                 NewBranchName=newbranchname,
-                                SourceCommitId=commit_id)
+                                SourceCommitId=commit_id).data.result
         return Branch(dot=self.dot, name=newbranchname)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from codecs import open
 
 setup(
     name='datadots-api',
-    version='0.2.2',
+    version='0.2.3',
     description='Datadots API',
     long_description=open('README.md', 'r').read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The latest version of `jsonrpcclient.clients.http_client` requires us to access `res.data.result` to extract the actual data returned [as documented here](https://jsonrpcclient.readthedocs.io/en/latest/api.html)

This PR returns `res.data.result` wherever we are using the jsonrpc client